### PR TITLE
Add support for completion block that fires after animation ends

### DIFF
--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -8,6 +8,8 @@
 
 @import QuartzCore;
 
+typedef void (^MBCircularProgressBarCompletionBlock)(BOOL finished);
+
 /**
  * The MBCircularProgressBarLayer class is a CALayer subclass that represents the underlying layer
  * of MBCircularProgressBarView.
@@ -133,5 +135,10 @@
  * Should show value string
  */
 @property (nonatomic,assign)  BOOL      showValueString;
+
+/**
+ * Completion block to call after animation stops
+ */
+@property (nonatomic,strong) MBCircularProgressBarCompletionBlock completionBlock;
 
 @end

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -180,6 +180,7 @@
             anim.fromValue = [[self presentationLayer]
                               valueForKey:@"value"];
             anim.duration = self.animationDuration;
+            anim.delegate = self;
             return anim;
         }
     }
@@ -187,5 +188,11 @@
     return [super actionForKey:event];
 }
 
+- (void) animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
+{
+    if (_completionBlock) {
+        _completionBlock(flag);
+    }
+}
 
 @end

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -132,4 +132,12 @@ IB_DESIGNABLE
  */
 -(void)setValue:(CGFloat)value animateWithDuration:(NSTimeInterval)duration;
 
+/**
+ * Set the value of the progress bar with animation
+ * @param value the new value
+ * @param duration animation duration in seconds
+ * @param complection block to call after animation stops
+ */
+-(void)setValue:(CGFloat)value animateWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL finished))completion;
+
 @end

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -133,10 +133,10 @@ IB_DESIGNABLE
 -(void)setValue:(CGFloat)value animateWithDuration:(NSTimeInterval)duration;
 
 /**
- * Set the value of the progress bar with animation
+ * Set the value of the progress bar with animation. Calls completion block after animation ends.
  * @param value the new value
  * @param duration animation duration in seconds
- * @param complection block to call after animation stops
+ * @param complection block to call after animation ends
  */
 -(void)setValue:(CGFloat)value animateWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL finished))completion;
 

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -280,4 +280,9 @@
     [self progressLayer].value = value;
 }
 
+-(void)setValue:(CGFloat)value animateWithDuration:(NSTimeInterval)duration completion:(void (^)(BOOL finished))completion {
+    [self progressLayer].completionBlock = completion;
+    [self setValue:value animateWithDuration:duration];
+}
+
 @end


### PR DESCRIPTION
I needed the ability to chain animation sequences similar to UIView's `animateWithDuration:completion` method. I added `setValue:animateWithDuration:completion` to enable animation chaining. 

Implements https://github.com/MatiBot/MBCircularProgressBar/issues/12
