### PR TITLE
Expose emptyLineStrokeColor

### DIFF
--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -98,6 +98,10 @@
  * The color of the background bar
  */
 @property (nonatomic,strong) UIColor    *emptyLineColor;
+/**
+ * The color of the background bar stroke line
+ */
+@property (nonatomic,strong) UIColor    *emptyLineStrokeColor;
 
 /*
  * Number of decimal places of the value [0,∞)

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -23,6 +23,7 @@
 @dynamic emptyLineWidth;
 @dynamic progressAngle;
 @dynamic emptyLineColor;
+@dynamic emptyLineStrokeColor;
 @dynamic emptyCapType;
 @dynamic progressCapType;
 @dynamic fontColor;
@@ -78,7 +79,7 @@
     
     
     CGContextAddPath(c, strokedArc);
-    CGContextSetStrokeColorWithColor(c, self.emptyLineColor.CGColor);
+    CGContextSetStrokeColorWithColor(c, self.emptyLineStrokeColor.CGColor);
     CGContextSetFillColorWithColor(c, self.emptyLineColor.CGColor);
     CGContextDrawPath(c, kCGPathFillStroke);
     

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -116,6 +116,11 @@ IB_DESIGNABLE
 @property (nonatomic,strong) IBInspectable UIColor   *emptyLineColor;
 
 /**
+ * The color of the background bar stroke color
+ */
+@property (nonatomic,strong) IBInspectable UIColor   *emptyLineStrokeColor;
+
+/**
  * The shape of the background bar cap	{kCGLineCapButt=0, kCGLineCapRound=1, kCGLineCapSquare=2} 
  */
 @property (nonatomic,assign) IBInspectable NSInteger emptyCapType;

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -49,6 +49,7 @@
     [self setProgressColor:[UIColor orangeColor]];
     [self setProgressCapType:kCGLineCapRound];
     [self setEmptyLineColor:[UIColor lightGrayColor]];
+    [self setEmptyLineStrokeColor:[UIColor lightGrayColor]];
     [self setFontColor:[UIColor blackColor]];
     [self setEmptyLineWidth:1.f];
     [self setProgressLineWidth:14.f];
@@ -173,6 +174,14 @@
 
 -(UIColor*)emptyLineColor{
     return self.progressLayer.emptyLineColor;
+}
+
+-(void)setEmptyLineStrokeColor:(UIColor *)emptyLineStrokeColor{
+    self.progressLayer.emptyLineStrokeColor = emptyLineStrokeColor;
+}
+
+-(UIColor*)emptyLineStrokeColor{
+    return self.progressLayer.emptyLineStrokeColor;
 }
 
 -(void)setProgressAngle:(CGFloat)progressAngle{


### PR DESCRIPTION
Previously the stroke colour was not configurable, but was inherited from emptyLineColor. This does not work well when using a semitransparent background colour. This PR exposes the emptyLineStrokeColor as a configurable UIColor property. 