### PR TITLE
Resource bundle removed

### DIFF
--- a/MBCircularProgressBar.podspec
+++ b/MBCircularProgressBar.podspec
@@ -25,9 +25,6 @@ a circular animatable & Interface Builder highly customizable progress bar
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'MBCircularProgressBar' => ['Pod/Assets/*.png']
-  }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'


### PR DESCRIPTION
An extra bundle is created for resource event though it is empty.
It could also be seen in white in targets section in Pods Project (in attached image). It is removed in this commit.
<img width="149" alt="screen shot 2016-05-21 at 8 07 37 pm" src="https://cloud.githubusercontent.com/assets/4197775/15449022/bf7c0bea-1f8f-11e6-942f-523afc53e6e9.png">
