### PR TITLE
Trailing & Baseline Offset Unit String

### DIFF
--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -55,6 +55,17 @@
 @property (nonatomic,copy)   NSString *unitString;
 
 /**
+ *  A bool indicating the placement of the unit string relative to the value (YES=right, NO=left)
+ */
+@property (nonatomic, assign) BOOL unitTrailing;
+
+/**
+ *  A bool indicating the baseline of the unit string relative to the value (YES=bottom, NO=top)
+ */
+@property (nonatomic, assign) CGFloat unitBaselineOffset;
+
+
+/**
  * The color of the value and unit text
  */
 @property (nonatomic,strong) UIColor  *fontColor;

--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -60,7 +60,7 @@
 @property (nonatomic, assign) BOOL unitTrailing;
 
 /**
- *  A bool indicating the baseline of the unit string relative to the value (YES=bottom, NO=top)
+ *  The offset (in points) of the unit string from the baseline     [0,∞)
  */
 @property (nonatomic, assign) CGFloat unitBaselineOffset;
 

--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -60,7 +60,7 @@
 @property (nonatomic, assign) BOOL unitTrailing;
 
 /**
- *  The offset (in points) of the unit string from the baseline     [0,∞)
+ *  The offset (in points) of the unit string from the baseline     (∞,∞)
  */
 @property (nonatomic, assign) CGFloat unitBaselineOffset;
 

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -33,6 +33,8 @@
 @dynamic unitFontName;
 @dynamic valueFontName;
 @dynamic showUnitString;
+@dynamic unitTrailing;
+@dynamic unitBaselineOffset;
 @dynamic showValueString;
 @dynamic textOffset;
 @dynamic countdown;
@@ -158,11 +160,13 @@
   
   // ad the unit only if specified
   if (self.showUnitString) {
-    NSDictionary* unitFontAttributes = @{NSFontAttributeName: [UIFont fontWithName: self.unitFontName size:self.unitFontSize == -1 ? rectSize.height/7 : self.unitFontSize], NSForegroundColorAttributeName: self.fontColor, NSParagraphStyleAttributeName: textStyle};
+      NSDictionary* unitFontAttributes = @{NSFontAttributeName: [UIFont fontWithName: self.unitFontName size:self.unitFontSize == -1 ? rectSize.height/7 : self.unitFontSize], NSForegroundColorAttributeName: self.fontColor, NSParagraphStyleAttributeName: textStyle, NSBaselineOffsetAttributeName: [NSNumber numberWithFloat:self.unitBaselineOffset]};
     
     NSAttributedString* unit =
     [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@", self.unitString] attributes:unitFontAttributes];
-    [text appendAttributedString:unit];
+      
+      // place the unit string before or after the value text
+      self.unitTrailing ? [text appendAttributedString:unit] : [text insertAttributedString:unit atIndex:0];
   }
   
   CGSize percentSize = [text size];

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -70,6 +70,16 @@ IB_DESIGNABLE
  */
 @property (nonatomic,copy)   IBInspectable NSString  *unitString;
 
+/**
+ *  A bool indicating the placement of the unit string relative to the value (YES=right, NO=left)
+ */
+@property (nonatomic, assign) IBInspectable BOOL unitTrailing;
+
+/**
+ *  A bool indicating the baseline of the unit string relative to the value (YES=bottom, NO=top)
+ */
+@property (nonatomic, assign) IBInspectable CGFloat unitBaselineOffset;
+
 /** 
  * The color of the value and unit text 
  */

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -76,7 +76,7 @@ IB_DESIGNABLE
 @property (nonatomic, assign) IBInspectable BOOL unitTrailing;
 
 /**
- *  A bool indicating the baseline of the unit string relative to the value (YES=bottom, NO=top)
+ *  The offset (in points) of the unit string from the baseline     [0,∞)
  */
 @property (nonatomic, assign) IBInspectable CGFloat unitBaselineOffset;
 

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -76,7 +76,7 @@ IB_DESIGNABLE
 @property (nonatomic, assign) IBInspectable BOOL unitTrailing;
 
 /**
- *  The offset (in points) of the unit string from the baseline     [0,∞)
+ *  The offset (in points) of the unit string from the baseline     (∞,∞)
  */
 @property (nonatomic, assign) IBInspectable CGFloat unitBaselineOffset;
 

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -42,6 +42,8 @@
     [self setContentScaleFactor:[[UIScreen mainScreen] scale]];
   
     [self setUnitString:@"%"];
+    [self setUnitTrailing:YES];
+    [self setUnitBaselineOffset:0.f];
     [self setValue:0.f];
     [self setMaxValue:100.f];
     [self setProgressRotationAngle:0.f];
@@ -149,6 +151,22 @@
 
 -(NSString*)unitString{
     return self.progressLayer.unitString;
+}
+
+-(void)setUnitTrailing:(BOOL)unitTrailing {
+    self.progressLayer.unitTrailing = unitTrailing;
+}
+
+-(BOOL)unitTrailing{
+    return self.progressLayer.unitTrailing;
+}
+
+-(void)setUnitBaselineOffset:(CGFloat)unitBaselineOffset {
+    self.progressLayer.unitBaselineOffset = unitBaselineOffset;
+}
+
+-(CGFloat)unitBaselineOffset{
+    return self.progressLayer.unitBaselineOffset;
 }
 
 -(void)setFontColor:(UIColor*)color{

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ valueFontName | NSString | The name of the font of the unit string | Any valid f
 unitFontSize | CGFloat | The font size of the unit text | [0,∞)
 unitString | NSString | The string that represents the units, usually % |
 unitTrailing | BOOL | A bool indicating the placement of the unit string relative to the value | {YES=right, NO=left}
-unitBaselineOffset | CGFloat | The offset (in points) of the unit string from the baseline | [0,∞)
+unitBaselineOffset | CGFloat | The offset (in points) of the unit string from the baseline | (∞,∞)
 fontColor | UIColor | The color of the value and unit text |
 decimalPlaces | NSInteger | Number of decimal places of the value | [0,∞)
 progressRotationAngle | CGFloat | Progress bar rotation (Clockewise)| [0,100]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ valueFontSize | CGFloat | The font size of the value text  | [0,∞)
 valueFontName | NSString | The name of the font of the unit string | Any valid font name
 unitFontSize | CGFloat | The font size of the unit text | [0,∞)
 unitString | NSString | The string that represents the units, usually % |
+unitTrailing | BOOL | A bool indicating the placement of the unit string relative to the value | {YES=right, NO=left}
+unitBaselineOffset | CGFloat | The offset (in points) of the unit string from the baseline | [0,∞)
 fontColor | UIColor | The color of the value and unit text |
 decimalPlaces | NSInteger | Number of decimal places of the value | [0,∞)
 progressRotationAngle | CGFloat | Progress bar rotation (Clockewise)| [0,100]


### PR DESCRIPTION
I've added properties to allow placing the unit string to the left or the right (default) of the value string. In using this library in my own project that heavily uses currencies, I found that the default position of the unit string to the right of the value was not appropriate for currencies that have leading unit characters. The unitTrailing property will place the unit string to the right (by default or if this value is YES/true) or to the left (NO/false).

Also, in looking through the open issues for this library, I noticed somebody had requested adjusting the unit string's baseline offset. The unitBaselineOffset property value will offset the unit string's baseline by the input value.

Both new properties are IBInspectable. 

It should be noted that extreme unitBaselineOffset values (either positive or negative) can force the baseline offset of the value portion of the string in the opposite direction.