### PR TITLE
Added support for animating progressColor & progressStrokeColor

### DIFF
--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -83,12 +83,12 @@ typedef NS_ENUM(NSInteger, MBCircularProgressBarAppearanceType) {
 /**
  * The color of the progress bar
  */
-@property (nonatomic,strong) UIColor    *progressColor;
+@property (nonatomic,assign) CGColorRef progressColor;
 
 /**
  * The color of the progress bar frame
  */
-@property (nonatomic,strong) UIColor    *progressStrokeColor;
+@property (nonatomic,assign) CGColorRef progressStrokeColor;
 
 /**
  * The shape of the progress bar cap	{kCGLineCapButt=0, kCGLineCapRound=1, kCGLineCapSquare=2}

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -135,8 +135,8 @@
 
     
     CGContextAddPath(c, strokedArc);
-    CGContextSetFillColorWithColor(c, self.progressColor.CGColor);
-    CGContextSetStrokeColorWithColor(c, self.progressStrokeColor.CGColor);
+    CGContextSetFillColorWithColor(c, self.progressColor);
+    CGContextSetStrokeColorWithColor(c, self.progressStrokeColor);
     CGContextDrawPath(c, kCGPathFillStroke);
     
     CGPathRelease(arc);
@@ -193,28 +193,28 @@
 
 #pragma mark - Override methods to support animations
 
++ (BOOL)isCustomAnimationKey:(NSString *)key {
+    return [key isEqualToString:@"value"] || [key isEqualToString:@"progressColor"] || [key isEqualToString:@"progressStrokeColor"];
+}
+    
 + (BOOL)needsDisplayForKey:(NSString *)key {
-    if ([key isEqualToString:@"value"]) {
-        return YES;
-    }
+    if ([self isCustomAnimationKey:key]) return true;
     return [super needsDisplayForKey:key];
 }
-
-- (id<CAAction>)actionForKey:(NSString *)event{
-    if ([self presentationLayer] != nil) {
-        if ([event isEqualToString:@"value"]) {  
-            id animation = [super actionForKey:@"backgroundColor"];
-            
-            if (animation == nil || [animation isEqual:[NSNull null]])
-            {
-                [self setNeedsDisplay];
-                return [NSNull null];
-            }
-            [animation setKeyPath:event];
-            [animation setFromValue:[self.presentationLayer valueForKey:@"value"]];
-            [animation setToValue:nil];
-            return animation;
+    
+- (id<CAAction>)actionForKey:(NSString *)event {
+    
+    if ([self presentationLayer] != nil && [[self class] isCustomAnimationKey:event]) {
+        id animation = [super actionForKey:@"backgroundColor"];
+        
+        if (animation == nil || [animation isEqual:[NSNull null]]) {
+            [self setNeedsDisplay];
+            return [NSNull null];
         }
+        [animation setKeyPath:event];
+        [animation setFromValue:[self.presentationLayer valueForKey:event]];
+        [animation setToValue:nil];
+        return animation;
     }
     
     return [super actionForKey:event];

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -131,11 +131,11 @@
 }
 
 -(void)setProgressColor:(UIColor*)color{
-    self.progressLayer.progressColor = color;
+    self.progressLayer.progressColor = color.CGColor;
 }
 
 -(UIColor*)progressColor{
-    return self.progressLayer.progressColor;
+    return [UIColor colorWithCGColor: self.progressLayer.progressColor];
 }
 
 -(void)setUnitFontSize:(CGFloat)unitFontSize{
@@ -171,11 +171,11 @@
 }
 
 -(void)setProgressStrokeColor:(UIColor*)color{
-    self.progressLayer.progressStrokeColor = color;
+    self.progressLayer.progressStrokeColor = color.CGColor;
 }
 
 -(UIColor*)progressStrokeColor{
-    return self.progressLayer.progressStrokeColor;
+    return [UIColor colorWithCGColor: self.progressLayer.progressStrokeColor];
 }
 
 -(void)setEmptyLineColor:(UIColor *)emptyLineColor{


### PR DESCRIPTION
I've added support to change `progressColor` & `progressStrokeColor` in an animation block.

This can be tested in `MBViewController` with the following animate body:

    CGFloat newValue = 100.f - self.progressBar.value;
    UIColor *newColor = (newValue < 50.f) ? [UIColor orangeColor] : [UIColor blueColor];
    
    [UIView animateWithDuration:self.animatedSwitch.on * 1.f animations:^{
        self.progressBar.value = newValue;
        self.progressBar.progressColor = newColor;
        self.progressBar.progressStrokeColor = newColor;
    }];

The declarations of both properties in `MBCircularProgressBarView` are unchanged as `UIColor`s so this change won't break anyone's code.